### PR TITLE
feat: inject financial context into AI chat with opt-out toggle

### DIFF
--- a/app/(tabs)/ai-chat.tsx
+++ b/app/(tabs)/ai-chat.tsx
@@ -36,10 +36,11 @@ const FOLLOW_UP_CHIPS = ["Tell me more", "Show breakdown", "Any tips?"];
 
 export default function AIChatScreen() {
   // Pull userProfile to get the dynamic currency
-  const { transactions, categories, userProfile } = useAppState();
+  const { transactions, categories, userProfile, accounts, budgetGoals, settings } = useAppState();
   const { colors } = useTheme();
 
   const currency = userProfile?.currency || "CAD";
+  const contextEnabled = settings.find((s) => s.key === "ai_context_enabled")?.value !== "0";
 
   // Key management
   const [keyChecked, setKeyChecked] = useState(false);
@@ -125,7 +126,10 @@ export default function AIChatScreen() {
         geminiHistory.current,
         transactions,
         categories,
-        currency // Passed currency here
+        accounts,
+        budgetGoals,
+        currency,
+        contextEnabled,
       );
       const botMsg: Message = {
         id: `b-${Date.now()}`,

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -87,6 +87,8 @@ export default function SettingsScreen() {
     settings.find((s) => s.key === "budget_alerts")?.value === "1";
   const weeklyDigest =
     settings.find((s) => s.key === "weekly_digest")?.value === "1";
+  const aiContext =
+    settings.find((s) => s.key === "ai_context_enabled")?.value !== "0";
 
   // ─── CSV Export state ─────────────────────────────────────────────────────
   const now = new Date();
@@ -590,6 +592,21 @@ export default function SettingsScreen() {
             <Switch
               value={weeklyDigest}
               onValueChange={(val) => handleToggle("weekly_digest", val)}
+              trackColor={{ false: colors.border, true: colors.accent }}
+              thumbColor={colors.textPrimary}
+            />
+          </View>
+          <View style={styles.itemDivider} />
+          <View style={styles.switchRow}>
+            <View>
+              <Text style={styles.itemTitleText}>AI Financial Context</Text>
+              <Text style={styles.itemSubText}>
+                Share spending summary with SyncBot via HTTPS
+              </Text>
+            </View>
+            <Switch
+              value={aiContext}
+              onValueChange={(val) => updateSetting("ai_context_enabled", val ? "1" : "0")}
               trackColor={{ false: colors.border, true: colors.accent }}
               thumbColor={colors.textPrimary}
             />

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -601,7 +601,7 @@ export default function SettingsScreen() {
             <View>
               <Text style={styles.itemTitleText}>AI Financial Context</Text>
               <Text style={styles.itemSubText}>
-                Share spending summary with SyncBot via HTTPS
+                Share financial summary with Google Gemini via HTTPS
               </Text>
             </View>
             <Switch

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -123,6 +123,9 @@ export async function initializeDatabase() {
   await database.runAsync(
     "INSERT OR IGNORE INTO settings (key, value) VALUES ('last_digest_at', '')",
   );
+  await database.runAsync(
+    "INSERT OR IGNORE INTO settings (key, value) VALUES ('ai_context_enabled', '1')",
+  );
 }
 
 // ─── Accounts ────────────────────────────────────────────────────────────────

--- a/lib/gemini.ts
+++ b/lib/gemini.ts
@@ -75,7 +75,10 @@ function buildSystemPrompt(
   const cutoff = new Date(now);
   cutoff.setDate(now.getDate() - 30);
 
-  const recent = transactions.filter((t) => new Date(t.date) >= cutoff);
+  const recent = transactions.filter((t) => {
+    const [y, m, d] = t.date.split("-").map(Number);
+    return new Date(y, m - 1, d) >= cutoff;
+  });
   const categoryMap = new Map(categories.map((c) => [c.id, c.name]));
 
   const expenseByCategory = new Map<string, number>();

--- a/lib/gemini.ts
+++ b/lib/gemini.ts
@@ -1,4 +1,4 @@
-import { Category, Transaction } from "@/lib/types";
+import { Account, BudgetGoal, Category, Transaction } from "@/lib/types";
 import * as SecureStore from "expo-secure-store";
 
 const GEMINI_KEY_STORE = "budgetsync_gemini_key";
@@ -67,7 +67,9 @@ async function getModel(key: string): Promise<string> {
 function buildSystemPrompt(
   transactions: Transaction[],
   categories: Category[],
-  currency: string
+  accounts: Account[],
+  budgetGoals: BudgetGoal[],
+  currency: string,
 ): string {
   const now = new Date();
   const cutoff = new Date(now);
@@ -92,8 +94,56 @@ function buildSystemPrompt(
 
   const breakdown = Array.from(expenseByCategory.entries())
     .sort((a, b) => b[1] - a[1])
+    .slice(0, 3)
     .map(([cat, amt]) => `  - ${cat}: ${currency} ${amt.toFixed(2)}`)
     .join("\n");
+
+  // Net worth
+  let assets = 0;
+  let liabilities = 0;
+  for (const a of accounts) {
+    if (a.type === "credit_card") liabilities += Math.abs(a.balance);
+    else assets += a.balance;
+  }
+  const netWorth = assets - liabilities;
+
+  const netWorthSection = `
+Net worth:
+- Assets: ${currency} ${assets.toFixed(2)} (across ${accounts.filter((a) => a.type !== "credit_card").length} account(s))
+- Liabilities: ${currency} ${liabilities.toFixed(2)} (across ${accounts.filter((a) => a.type === "credit_card").length} card(s))
+- Net worth: ${currency} ${netWorth.toFixed(2)}`;
+
+  // Budget goal status
+  let goalSection = "";
+  if (budgetGoals.length > 0) {
+    const goalLines: string[] = [];
+    for (const goal of budgetGoals) {
+      const catName = categoryMap.get(goal.category_id) ?? "Unknown";
+      const periodTxs = transactions.filter((t) => {
+        if (t.type !== "expense" || t.category_id !== goal.category_id) return false;
+        const [y, m, d] = t.date.split("-").map(Number);
+        const txDate = new Date(y, m - 1, d);
+        if (goal.period === "monthly") {
+          return txDate.getFullYear() === now.getFullYear() && txDate.getMonth() === now.getMonth();
+        } else if (goal.period === "weekly") {
+          const dayOfWeek = now.getDay();
+          const mondayOffset = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+          const weekStart = new Date(now);
+          weekStart.setDate(now.getDate() - mondayOffset);
+          weekStart.setHours(0, 0, 0, 0);
+          const weekEnd = new Date(weekStart);
+          weekEnd.setDate(weekStart.getDate() + 7);
+          return txDate >= weekStart && txDate < weekEnd;
+        } else {
+          return txDate.getFullYear() === now.getFullYear();
+        }
+      });
+      const spent = periodTxs.reduce((s, t) => s + t.amount, 0);
+      const pct = goal.limit_amount > 0 ? Math.round((spent / goal.limit_amount) * 100) : 0;
+      goalLines.push(`  - ${catName} (${goal.period}): ${currency} ${spent.toFixed(2)} / ${currency} ${goal.limit_amount.toFixed(2)} (${pct}%)`);
+    }
+    goalSection = `\nBudget goals:\n${goalLines.join("\n")}`;
+  }
 
   return `You are SyncBot, a friendly and concise personal finance assistant inside the BudgetSync app. Answer the user's questions using their financial data below. The user's preferred currency is ${currency}. ALWAYS format money values using ${currency}. Keep responses brief and actionable.
 
@@ -101,8 +151,13 @@ User's last 30 days:
 - Total income: ${currency} ${totalIncome.toFixed(2)}
 - Total expenses: ${currency} ${totalExpense.toFixed(2)}
 - Net: ${currency} ${(totalIncome - totalExpense).toFixed(2)}
-- Expense breakdown by category:
-${breakdown || "  (no expense data yet)"}`;
+- Top spending categories:
+${breakdown || "  (no expense data yet)"}
+${netWorthSection}${goalSection}`;
+}
+
+function buildGenericPrompt(currency: string): string {
+  return `You are SyncBot, a friendly and concise personal finance assistant inside the BudgetSync app. The user has disabled financial context sharing, so you do not have access to their data. Answer general personal finance questions helpfully. The user's preferred currency is ${currency}. ALWAYS format money values using ${currency}. Keep responses brief and actionable.`;
 }
 
 export async function sendMessage(
@@ -110,7 +165,10 @@ export async function sendMessage(
   history: GeminiTurn[],
   transactions: Transaction[],
   categories: Category[],
-  currency: string
+  accounts: Account[],
+  budgetGoals: BudgetGoal[],
+  currency: string,
+  contextEnabled: boolean,
 ): Promise<string> {
   const key = await getGeminiKey();
   if (!key) throw new Error("NO_KEY");
@@ -118,9 +176,13 @@ export async function sendMessage(
   const model = await getModel(key);
   const url = `${GEMINI_LIST_URL}/${model}:generateContent?key=${key}`;
 
+  const systemText = contextEnabled
+    ? buildSystemPrompt(transactions, categories, accounts, budgetGoals, currency)
+    : buildGenericPrompt(currency);
+
   const body = {
     system_instruction: {
-      parts: [{ text: buildSystemPrompt(transactions, categories, currency) }],
+      parts: [{ text: systemText }],
     },
     contents: [
       ...history,


### PR DESCRIPTION
Closes #24

## Summary
- Enhance `buildSystemPrompt()` with net worth (assets/liabilities), top-3 spending categories, and budget goal status with period-aware spend tracking
- Add `ai_context_enabled` setting (defaults to on) with a toggle in Settings > ALERTS
- When disabled, SyncBot uses a generic prompt without any financial data
- No raw IDs, account numbers, or last4 digits are ever sent to the API

## Test plan
- [x] Open AI chat, ask "Am I on budget?" -- response references net worth, budget goals, top 3 categories
- [x] Settings > ALERTS > toggle off "AI Financial Context"
- [x] New chat, same question -- generic response without financial numbers
- [x] Toggle back on -- context returns
- [x] Verify no account IDs or last4 appear in AI responses